### PR TITLE
Adding auto release

### DIFF
--- a/.github/auto-release-config.yml
+++ b/.github/auto-release-config.yml
@@ -38,10 +38,13 @@ categories:
 change-template: |
   <details>
     <summary>$TITLE @$AUTHOR (#$NUMBER)</summary>
+
     $BODY
   </details>
+
 template: |
   $CHANGES
+
 replacers:
 # Remove irrelevant information from Renovate bot
 - search: '/(?<=---\s)\s*^#.*(Renovate configuration|Configuration)(?:.|\n)*?This PR has been generated .*/gm'

--- a/.github/auto-release.yml
+++ b/.github/auto-release.yml
@@ -1,0 +1,51 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: '$RESOLVED_VERSION'
+version-template: '$MAJOR.$MINOR.$PATCH'
+version-resolver:
+  major:
+    labels:
+    - 'major'
+  minor:
+    labels:
+    - 'minor'
+    - 'enhancement'
+  patch:
+    labels:
+    - 'auto-update'
+    - 'patch'
+    - 'fix'
+    - 'bugfix'
+    - 'bug'
+    - 'hotfix'
+    - 'no-release'
+  default: 'minor'
+
+categories:
+- title: '🚀 Enhancements'
+  labels:
+  - 'enhancement'
+  - 'patch'
+- title: '🐛 Bug Fixes'
+  labels:
+  - 'fix'
+  - 'bugfix'
+  - 'bug'
+  - 'hotfix'
+- title: '🤖 Automatic Updates'
+  labels:
+  - 'auto-update'
+
+change-template: |
+  <details>
+    <summary>$TITLE @$AUTHOR (#$NUMBER)</summary>
+    $BODY
+  </details>
+template: |
+  $CHANGES
+replacers:
+# Remove irrelevant information from Renovate bot
+- search: '/(?<=---\s)\s*^#.*(Renovate configuration|Configuration)(?:.|\n)*?This PR has been generated .*/gm'
+  replace: ''
+# Remove Renovate bot banner image
+- search: '/\[!\[[^\]]*Renovate\][^\]]*\](\([^)]*\))?\s*\n+/gm'
+  replace: ''

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,17 @@
+name: "auto-release"
+on:
+  push:
+    branches:
+      - main
+      - master
+      - production
+
+jobs:
+  auto-release:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: cloudposse/github-action-auto-release@main
+      with:
+        prerelease: false
+        publish: true
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,3 +1,8 @@
+# Please see
+# https://github.com/cloudposse/github-action-auto-release/blob/main/README.md
+# and
+# https://github.com/release-drafter/release-drafter
+# for information on customizing this action's behavior.
 name: "auto-release"
 on:
   push:
@@ -5,13 +10,16 @@ on:
       - main
       - master
       - production
+  workflow_dispatch:
 
 jobs:
   auto-release:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: cloudposse/github-action-auto-release@main
-      with:
-        prerelease: false
-        publish: true
-        token: ${{ secrets.GITHUB_TOKEN }}
+    # For development reasons, this action is pinned to the `main` branch.
+    # However, we recommend that you choose a specific release to pin to.
+    # Consult https://github.com/cloudposse/github-action-auto-release/releases for a list of available releases.
+    uses: cloudposse/github-action-auto-release/.github/workflows/auto-release-reusable.yml@main
+    with:
+      prerelease: false
+      publish: true
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate-codeowners-reusable.yml
+++ b/.github/workflows/validate-codeowners-reusable.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
     secrets:
       token:
-        required: false
+        required: true
 
 jobs:
   validate-codeowners:

--- a/.github/workflows/validate-codeowners-reusable.yml
+++ b/.github/workflows/validate-codeowners-reusable.yml
@@ -4,7 +4,6 @@ on:
     secrets:
       token:
         required: false
-        default: ${{ secrets.CODEOWNERS_VALIDATOR_TOKEN_PUBLIC }}
 
 jobs:
   validate-codeowners:

--- a/.github/workflows/validate-codeowners-reusable.yml
+++ b/.github/workflows/validate-codeowners-reusable.yml
@@ -1,0 +1,15 @@
+name: "validate-codeowners-reusable"
+on:
+  workflow_call:
+    secrets:
+      token:
+        required: false
+        default: ${{ secrets.CODEOWNERS_VALIDATOR_TOKEN_PUBLIC }}
+
+jobs:
+  validate-codeowners:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: cloudposse/github-action-validate-codeowners@main
+      with:
+        token: ${{ secrets.token }}

--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -1,9 +1,9 @@
 name: "validate-codeowners"
 on:
-  pull_request:
+  pull_request_target:
 
 jobs:
   validate-codeowners:
-    uses: cloudposse/github-action-validate-codeowners/.github/workflows/validate-codeowners-reusable.yml@adding_auto-release
+    uses: cloudposse/github-action-validate-codeowners/.github/workflows/validate-codeowners-reusable.yml@main
     secrets:
       token: ${{ secrets.CODEOWNERS_VALIDATOR_TOKEN_PUBLIC }}

--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -6,6 +6,6 @@ jobs:
   validate-codeowners:
     runs-on: ubuntu-latest
     steps:
-    - uses: cloudposse/github-action-validate-codeowners@main
+    - uses: cloudposse/github-action-validate-codeowners/.github/workflows/validate-codeowners-reusable.yml@adding_auto-release
       with:
         token: ${{ secrets.CODEOWNERS_VALIDATOR_TOKEN_PUBLIC }}

--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -4,8 +4,6 @@ on:
 
 jobs:
   validate-codeowners:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: cloudposse/github-action-validate-codeowners/.github/workflows/validate-codeowners-reusable.yml@adding_auto-release
-      with:
-        token: ${{ secrets.CODEOWNERS_VALIDATOR_TOKEN_PUBLIC }}
+    uses: cloudposse/github-action-validate-codeowners/.github/workflows/validate-codeowners-reusable.yml@adding_auto-release
+    secrets:
+      token: ${{ secrets.CODEOWNERS_VALIDATOR_TOKEN_PUBLIC }}

--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -1,6 +1,6 @@
 name: "validate-codeowners"
 on:
-  pull_request_target:
+  pull_request:
 
 jobs:
   validate-codeowners:

--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -1,6 +1,6 @@
 name: "validate-codeowners"
 on:
-  pull_request:
+  pull_request_target:
 
 jobs:
   validate-codeowners:


### PR DESCRIPTION
## what

Adding [`auto-release`](https://github.com/cloudposse/github-action-auto-release).

Also, hardening the `pull_request:` trigger for `validate-codeowners.yml` to the more secure `pull_request-target:` trigger.

Also, moving to reusable workflow topology.

## why

`auto-release` is being adding to improve release drafting.

The `pull_request:` target is being hardened for long-term security.

The reusable workflow topology is being adopted to enable the use of custom GitHub runners.

## references

CPCO-584