### PR TITLE
enabling version pinning

### DIFF
--- a/.github/workflows/validate-codeowners-reusable.yml
+++ b/.github/workflows/validate-codeowners-reusable.yml
@@ -9,6 +9,6 @@ jobs:
   validate-codeowners:
     runs-on: ubuntu-latest
     steps:
-    - uses: cloudposse/github-action-validate-codeowners@main
+    - uses: cloudposse/github-action-validate-codeowners@0.1.0
       with:
         token: ${{ secrets.token }}


### PR DESCRIPTION
## what
* Pinning validate-codeowners-reusable.yml to version 0.1.0

## why
* This allows users to pin to action version `0.1.0` by editing their repos' copies of `validate-codeowners.yml` (not `validate-codeowners-reusable.yml`) to pin to `0.1.1` (not `0.1.0`), this current release.