### PR TITLE
adding workflow_dispatch trigger for validate-codeowners.yml

### DIFF
--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -1,6 +1,7 @@
 name: "validate-codeowners"
 on:
   pull_request_target:
+  workflow_dispatch:
 
 jobs:
   validate-codeowners:


### PR DESCRIPTION
## what
* Adding `workflow_dispatch` trigger to `.github/workflows/validate-codeowners.yml`

## why
* This will make it easier to debug the workflow.